### PR TITLE
cmd/initContainer: Bind mount /run/systemd/system

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -56,6 +56,7 @@ var (
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},
+		{"/run/systemd/system", "/run/host/run/systemd/system", ""},
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
 		{"/tmp", "/run/host/tmp", "rslave"},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},


### PR DESCRIPTION
Required for systemd --user to realize the system was booted with
systemd.

Signed-off-by: Sebastian Wick <sebastian.wick@redhat.com>