### PR TITLE
cmd/create: use the host cgroup namespace

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -389,6 +389,10 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"--env", toolboxPathEnvArg,
 	}
 
+	createArgs = append(createArgs, []string{
+		"--cgroupns=host",
+	}...)
+
 	createArgs = append(createArgs, xdgRuntimeDirEnv...)
 
 	createArgs = append(createArgs, []string{


### PR DESCRIPTION
Podman creates a cgroup namespace for cgroups v2 by default. The host
cgroupfs is mounted at /sys/fs/cgroup giving an inconsistent view of the
cgroups. There is no need for a cgroup namespace with toolbox so just
use the host namespace.

Signed-off-by: Sebastian Wick <sebastian.wick@redhat.com>