### PR TITLE
cmd/run: add --preserve-fds command-line argument

### DIFF
--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -7,6 +7,7 @@ toolbox\-run - Run a command in an existing toolbox container
 **toolbox run** [*--container NAME* | *-c NAME*]
             [*--distro DISTRO* | *-d DISTRO*]
             [*--release RELEASE* | *-r RELEASE*]
+            [*--preserve-fds N*]
             [*COMMAND*]
 
 ## DESCRIPTION
@@ -41,6 +42,11 @@ matches the host system.
 
 Run command inside a toolbox container for a different operating system
 RELEASE than the host.
+
+**--preserve-fds** N
+
+Pass down to the process N additional file descriptors (in addition to 0, 1,
+2).  The total FDs will be 3+N.
 
 ## EXIT STATUS
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -33,9 +34,10 @@ import (
 
 var (
 	runFlags struct {
-		container string
-		distro    string
-		release   string
+		container    string
+		distro       string
+		release      string
+		preserve_fds int
 	}
 
 	runFallbackCommands = [][]string{{"/bin/bash", "-l"}}
@@ -70,6 +72,12 @@ func init() {
 		"r",
 		"",
 		"Run command inside a toolbox container for a different operating system release than the host")
+
+	flags.IntVarP(&runFlags.preserve_fds,
+		"preserve-fds",
+		"",
+		0,
+		"Forward this many file descriptors (starting from fd 3)")
 
 	runCmd.SetHelpFunc(runHelp)
 
@@ -474,6 +482,10 @@ func constructExecArgs(container string,
 	}...)
 
 	execArgs = append(execArgs, envOptions...)
+
+	if runFlags.preserve_fds != 0 {
+		execArgs = append(execArgs, "--preserve-fds="+strconv.Itoa(runFlags.preserve_fds))
+	}
 
 	execArgs = append(execArgs, []string{
 		container,


### PR DESCRIPTION
This mirrors the --preserve-fds argument of podman.

Fixes https://github.com/containers/toolbox/issues/1066

https://github.com/containers/toolbox/pull/1067

Signed-off-by: Allison Karlitskaya <allison.karlitskaya@redhat.com>