### PR TITLE
pkg/utils: find the runtime directory with missing XDG_RUNTIME_DIR

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -423,6 +423,7 @@ func GetRuntimeDirectory(targetUser *user.User) (string, error) {
 	if uid == 0 {
 		runtimeDirectory = "/run"
 	} else {
+		EnsureXdgRuntimeDirIsSet(uid)
 		runtimeDirectory = os.Getenv("XDG_RUNTIME_DIR")
 	}
 


### PR DESCRIPTION
`toolbox run` times out waiting for the `container-initialized` file in
the wrong runtime directory if XDG_RUNTIME_DIR is not set. Be smarter
about finding the correct runtime directory.

Fixes: #995
Signed-off-by: Sebastian Wick <sebastian.wick@redhat.com>